### PR TITLE
mtu parameter added to napalm

### DIFF
--- a/netbox_netprod_importer/importer.py
+++ b/netbox_netprod_importer/importer.py
@@ -172,9 +172,7 @@ class DeviceImporter(ContextDecorator):
                     napalm_ifprops["description"] or ""
                 )[:100],
                 "mac_address": napalm_ifprops["mac_address"] or None,
-                # wait for this pull request
-                # https://github.com/napalm-automation/napalm/pull/531
-                "mtu": napalm_ifprops.get("mtu", None),
+                "mtu": napalm_ifprops["mtu"] if napalm_ifprops["mtu"] else None,
                 "type": _type,
                 "mode": mode,
                 "untagged_vlan": None,

--- a/netbox_netprod_importer/importer.py
+++ b/netbox_netprod_importer/importer.py
@@ -172,7 +172,7 @@ class DeviceImporter(ContextDecorator):
                     napalm_ifprops["description"] or ""
                 )[:100],
                 "mac_address": napalm_ifprops["mac_address"] or None,
-                "mtu": napalm_ifprops["mtu"] if napalm_ifprops["mtu"] else None,
+                "mtu": napalm_ifprops["mtu"] or None,
                 "type": _type,
                 "mode": mode,
                 "untagged_vlan": None,

--- a/tests/mock_driver/global/cisco/ios/get_interfaces.1
+++ b/tests/mock_driver/global/cisco/ios/get_interfaces.1
@@ -770,7 +770,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B6",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/12": {
         "is_enabled": true,

--- a/tests/mock_driver/global/cisco/ios/get_interfaces.1
+++ b/tests/mock_driver/global/cisco/ios/get_interfaces.1
@@ -5,7 +5,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/2": {
         "is_enabled": true,
@@ -13,7 +14,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/3": {
         "is_enabled": true,
@@ -21,7 +23,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:79",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/4": {
         "is_enabled": true,
@@ -29,7 +32,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7A",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/5": {
         "is_enabled": true,
@@ -37,7 +41,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7B",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/6": {
         "is_enabled": true,
@@ -45,7 +50,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7C",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/7": {
         "is_enabled": true,
@@ -53,7 +59,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7D",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/8": {
         "is_enabled": false,
@@ -61,7 +68,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/9": {
         "is_enabled": true,
@@ -69,7 +77,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7F",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/10": {
         "is_enabled": false,
@@ -77,7 +86,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/11": {
         "is_enabled": true,
@@ -85,7 +95,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:81",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/12": {
         "is_enabled": false,
@@ -93,7 +104,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/13": {
         "is_enabled": false,
@@ -101,7 +113,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/14": {
         "is_enabled": false,
@@ -109,7 +122,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/15": {
         "is_enabled": false,
@@ -117,7 +131,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/16": {
         "is_enabled": false,
@@ -125,7 +140,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/17": {
         "is_enabled": false,
@@ -133,7 +149,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/18": {
         "is_enabled": false,
@@ -141,7 +158,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/19": {
         "is_enabled": false,
@@ -149,7 +167,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/20": {
         "is_enabled": false,
@@ -157,7 +176,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/21": {
         "is_enabled": false,
@@ -165,7 +185,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/22": {
         "is_enabled": false,
@@ -173,7 +194,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/23": {
         "is_enabled": false,
@@ -181,7 +203,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/24": {
         "is_enabled": true,
@@ -189,7 +212,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8E",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/25": {
         "is_enabled": true,
@@ -197,7 +221,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8F",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/26": {
         "is_enabled": false,
@@ -205,7 +230,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/27": {
         "is_enabled": true,
@@ -213,7 +239,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:91",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/28": {
         "is_enabled": false,
@@ -221,7 +248,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/29": {
         "is_enabled": false,
@@ -229,7 +257,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/30": {
         "is_enabled": false,
@@ -237,7 +266,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/31": {
         "is_enabled": false,
@@ -245,7 +275,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/32": {
         "is_enabled": false,
@@ -253,7 +284,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/1": {
         "is_enabled": true,
@@ -261,7 +293,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/2": {
         "is_enabled": true,
@@ -269,7 +302,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/3": {
         "is_enabled": true,
@@ -277,7 +311,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:51",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/4": {
         "is_enabled": true,
@@ -285,7 +320,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:52",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/5": {
         "is_enabled": true,
@@ -293,7 +329,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:53",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/6": {
         "is_enabled": true,
@@ -301,7 +338,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:54",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/7": {
         "is_enabled": true,
@@ -309,7 +347,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:55",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/8": {
         "is_enabled": false,
@@ -317,7 +356,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/9": {
         "is_enabled": false,
@@ -325,7 +365,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/10": {
         "is_enabled": false,
@@ -333,7 +374,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/11": {
         "is_enabled": false,
@@ -341,7 +383,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/12": {
         "is_enabled": false,
@@ -349,7 +392,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/13": {
         "is_enabled": false,
@@ -357,7 +401,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/14": {
         "is_enabled": false,
@@ -365,7 +410,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/15": {
         "is_enabled": true,
@@ -373,7 +419,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5D",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/16": {
         "is_enabled": true,
@@ -381,7 +428,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5E",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/17": {
         "is_enabled": true,
@@ -389,7 +437,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5F",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/18": {
         "is_enabled": true,
@@ -397,7 +446,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:60",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/19": {
         "is_enabled": true,
@@ -405,7 +455,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:61",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/20": {
         "is_enabled": true,
@@ -413,7 +464,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:62",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/21": {
         "is_enabled": true,
@@ -421,7 +473,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:63",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/22": {
         "is_enabled": true,
@@ -429,7 +482,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:64",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/23": {
         "is_enabled": false,
@@ -437,7 +491,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/24": {
         "is_enabled": false,
@@ -445,7 +500,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/25": {
         "is_enabled": false,
@@ -453,7 +509,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/26": {
         "is_enabled": false,
@@ -461,7 +518,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/27": {
         "is_enabled": true,
@@ -469,7 +527,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/28": {
         "is_enabled": true,
@@ -477,7 +536,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/29": {
         "is_enabled": true,
@@ -485,7 +545,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/30": {
         "is_enabled": false,
@@ -493,7 +554,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/31": {
         "is_enabled": false,
@@ -501,7 +563,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/32": {
         "is_enabled": false,
@@ -509,7 +572,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/1": {
         "is_enabled": true,
@@ -517,7 +581,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/2": {
         "is_enabled": true,
@@ -525,7 +590,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/3": {
         "is_enabled": true,
@@ -533,7 +599,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3D",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/4": {
         "is_enabled": true,
@@ -541,7 +608,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3E",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/5": {
         "is_enabled": true,
@@ -549,7 +617,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3F",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/6": {
         "is_enabled": false,
@@ -557,7 +626,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/7": {
         "is_enabled": true,
@@ -565,7 +635,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:41",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/8": {
         "is_enabled": true,
@@ -573,7 +644,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:42",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet1/3/9": {
         "is_enabled": false,
@@ -581,7 +653,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet1/3/10": {
         "is_enabled": false,
@@ -589,7 +662,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "mgmt0": {
         "is_enabled": false,
@@ -597,7 +671,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/1": {
         "is_enabled": true,
@@ -605,7 +680,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/2": {
         "is_enabled": true,
@@ -613,7 +689,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/3": {
         "is_enabled": true,
@@ -621,7 +698,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:AE",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/4": {
         "is_enabled": true,
@@ -629,7 +707,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:AF",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/5": {
         "is_enabled": true,
@@ -637,7 +716,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B0",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/6": {
         "is_enabled": true,
@@ -645,7 +725,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B1",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/7": {
         "is_enabled": true,
@@ -653,7 +734,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B2",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/8": {
         "is_enabled": false,
@@ -661,7 +743,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/9": {
         "is_enabled": true,
@@ -669,7 +752,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B4",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/10": {
         "is_enabled": true,
@@ -677,7 +761,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B5",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/11": {
         "is_enabled": true,
@@ -693,7 +778,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B7",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/13": {
         "is_enabled": false,
@@ -701,7 +787,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/14": {
         "is_enabled": false,
@@ -709,7 +796,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/15": {
         "is_enabled": true,
@@ -717,7 +805,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:BA",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/16": {
         "is_enabled": false,
@@ -725,7 +814,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/17": {
         "is_enabled": false,
@@ -733,7 +823,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/18": {
         "is_enabled": false,
@@ -741,7 +832,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/19": {
         "is_enabled": false,
@@ -749,7 +841,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/20": {
         "is_enabled": true,
@@ -757,7 +850,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:BF",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/21": {
         "is_enabled": true,
@@ -765,7 +859,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C0",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/22": {
         "is_enabled": false,
@@ -773,7 +868,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/23": {
         "is_enabled": true,
@@ -781,7 +877,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C2",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/24": {
         "is_enabled": true,
@@ -789,7 +886,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C3",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/25": {
         "is_enabled": true,
@@ -797,7 +895,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C4",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/26": {
         "is_enabled": false,
@@ -805,7 +904,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/27": {
         "is_enabled": true,
@@ -813,7 +913,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C6",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/28": {
         "is_enabled": false,
@@ -821,7 +922,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/29": {
         "is_enabled": false,
@@ -829,7 +931,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/30": {
         "is_enabled": false,
@@ -837,7 +940,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/31": {
         "is_enabled": false,
@@ -845,7 +949,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/32": {
         "is_enabled": false,
@@ -853,7 +958,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/1": {
         "is_enabled": true,
@@ -861,7 +967,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/2": {
         "is_enabled": true,
@@ -869,7 +976,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/3": {
         "is_enabled": true,
@@ -877,7 +985,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:64",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/4": {
         "is_enabled": true,
@@ -885,7 +994,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:65",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/5": {
         "is_enabled": true,
@@ -893,7 +1003,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:66",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/6": {
         "is_enabled": true,
@@ -901,7 +1012,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:67",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/7": {
         "is_enabled": true,
@@ -909,7 +1021,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:68",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/8": {
         "is_enabled": false,
@@ -917,7 +1030,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/9": {
         "is_enabled": false,
@@ -925,7 +1039,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/10": {
         "is_enabled": false,
@@ -933,7 +1048,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/11": {
         "is_enabled": false,
@@ -941,7 +1057,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/12": {
         "is_enabled": false,
@@ -949,7 +1066,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/13": {
         "is_enabled": false,
@@ -957,7 +1075,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/14": {
         "is_enabled": false,
@@ -965,7 +1084,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/15": {
         "is_enabled": true,
@@ -973,7 +1093,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:70",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/16": {
         "is_enabled": true,
@@ -981,7 +1102,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:71",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/17": {
         "is_enabled": true,
@@ -989,7 +1111,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:72",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/18": {
         "is_enabled": true,
@@ -997,7 +1120,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:73",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/19": {
         "is_enabled": true,
@@ -1005,7 +1129,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:74",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/20": {
         "is_enabled": true,
@@ -1013,7 +1138,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:75",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/21": {
         "is_enabled": true,
@@ -1021,7 +1147,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:76",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/22": {
         "is_enabled": true,
@@ -1029,7 +1156,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:77",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/23": {
         "is_enabled": true,
@@ -1037,7 +1165,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:78",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/24": {
         "is_enabled": false,
@@ -1045,7 +1174,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/25": {
         "is_enabled": false,
@@ -1053,7 +1183,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/26": {
         "is_enabled": false,
@@ -1061,7 +1192,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/27": {
         "is_enabled": true,
@@ -1069,7 +1201,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/28": {
         "is_enabled": true,
@@ -1077,7 +1210,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/29": {
         "is_enabled": true,
@@ -1085,7 +1219,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/30": {
         "is_enabled": true,
@@ -1093,7 +1228,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7F",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/31": {
         "is_enabled": true,
@@ -1101,7 +1237,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:80",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/32": {
         "is_enabled": true,
@@ -1109,7 +1246,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:81",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/1": {
         "is_enabled": true,
@@ -1117,7 +1255,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/2": {
         "is_enabled": true,
@@ -1125,7 +1264,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/3": {
         "is_enabled": false,
@@ -1133,7 +1273,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/4": {
         "is_enabled": true,
@@ -1141,7 +1282,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:E1",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/5": {
         "is_enabled": false,
@@ -1149,7 +1291,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/6": {
         "is_enabled": true,
@@ -1157,7 +1300,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:E3",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/7": {
         "is_enabled": false,
@@ -1165,7 +1309,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/8": {
         "is_enabled": false,
@@ -1173,7 +1318,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet2/3/9": {
         "is_enabled": false,
@@ -1181,7 +1327,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet2/3/10": {
         "is_enabled": false,
@@ -1189,7 +1336,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Loopback0": {
         "is_enabled": true,
@@ -1197,7 +1345,8 @@
         "description": "",
         "mac_address": "",
         "last_flapped": -1.0,
-        "speed": 8000
+        "speed": 8000,
+        "mtu": 1500
     },
     "Port-channel1": {
         "is_enabled": true,
@@ -1205,7 +1354,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:79",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel2": {
         "is_enabled": true,
@@ -1213,7 +1363,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8F",
         "last_flapped": -1.0,
-        "speed": 20000
+        "speed": 20000,
+        "mtu": 1500
     },
     "Port-channel3": {
         "is_enabled": true,
@@ -1221,7 +1372,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7B",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel4": {
         "is_enabled": true,
@@ -1229,7 +1381,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:53",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel5": {
         "is_enabled": true,
@@ -1237,7 +1390,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3D",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel6": {
         "is_enabled": true,
@@ -1245,7 +1399,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8E",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel7": {
         "is_enabled": true,
@@ -1253,7 +1408,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B4",
         "last_flapped": -1.0,
-        "speed": 4000
+        "speed": 4000,
+        "mtu": 1500
     },
     "Port-channel10": {
         "is_enabled": true,
@@ -1261,7 +1417,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel20": {
         "is_enabled": true,
@@ -1269,7 +1426,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel21": {
         "is_enabled": true,
@@ -1277,7 +1435,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5D",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel22": {
         "is_enabled": true,
@@ -1285,7 +1444,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5E",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel23": {
         "is_enabled": true,
@@ -1293,7 +1453,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5F",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel24": {
         "is_enabled": true,
@@ -1301,7 +1462,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:60",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel25": {
         "is_enabled": true,
@@ -1309,7 +1471,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:61",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel26": {
         "is_enabled": true,
@@ -1317,7 +1480,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:62",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel27": {
         "is_enabled": true,
@@ -1325,7 +1489,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:76",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel28": {
         "is_enabled": true,
@@ -1333,7 +1498,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:77",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel29": {
         "is_enabled": true,
@@ -1341,7 +1507,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:91",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel30": {
         "is_enabled": true,
@@ -1349,7 +1516,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:65",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel31": {
         "is_enabled": true,
@@ -1357,7 +1525,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7D",
         "last_flapped": -1.0,
-        "speed": 20000
+        "speed": 20000,
+        "mtu": 1500
     },
     "Port-channel32": {
         "is_enabled": true,
@@ -1365,7 +1534,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B2",
         "last_flapped": -1.0,
-        "speed": 20000
+        "speed": 20000,
+        "mtu": 1500
     },
     "Port-channel100": {
         "is_enabled": true,
@@ -1373,7 +1543,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7C",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Vlan1": {
         "is_enabled": false,
@@ -1381,7 +1552,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan4": {
         "is_enabled": true,
@@ -1389,7 +1561,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan7": {
         "is_enabled": true,
@@ -1397,7 +1570,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan502": {
         "is_enabled": true,
@@ -1405,7 +1579,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan510": {
         "is_enabled": true,
@@ -1413,7 +1588,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan538": {
         "is_enabled": true,
@@ -1421,7 +1597,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan601": {
         "is_enabled": true,
@@ -1429,7 +1606,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan602": {
         "is_enabled": true,
@@ -1437,7 +1615,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan606": {
         "is_enabled": true,
@@ -1445,7 +1624,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan607": {
         "is_enabled": true,
@@ -1453,7 +1633,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan608": {
         "is_enabled": true,
@@ -1461,7 +1642,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan609": {
         "is_enabled": true,
@@ -1469,7 +1651,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan610": {
         "is_enabled": true,
@@ -1477,7 +1660,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan702": {
         "is_enabled": true,
@@ -1485,7 +1669,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan707": {
         "is_enabled": true,
@@ -1493,7 +1678,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan710": {
         "is_enabled": true,
@@ -1501,7 +1687,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan711": {
         "is_enabled": true,
@@ -1509,7 +1696,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan736": {
         "is_enabled": true,
@@ -1517,7 +1705,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan745": {
         "is_enabled": true,
@@ -1525,7 +1714,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan746": {
         "is_enabled": true,
@@ -1533,7 +1723,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan754": {
         "is_enabled": true,
@@ -1541,7 +1732,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan760": {
         "is_enabled": true,
@@ -1549,7 +1741,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan762": {
         "is_enabled": false,
@@ -1557,7 +1750,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan764": {
         "is_enabled": false,
@@ -1565,7 +1759,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan765": {
         "is_enabled": false,
@@ -1573,7 +1768,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan766": {
         "is_enabled": true,
@@ -1581,7 +1777,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan772": {
         "is_enabled": true,
@@ -1589,7 +1786,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan778": {
         "is_enabled": true,
@@ -1597,7 +1795,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan783": {
         "is_enabled": true,
@@ -1605,7 +1804,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan786": {
         "is_enabled": true,
@@ -1613,7 +1813,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan788": {
         "is_enabled": true,
@@ -1621,7 +1822,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan790": {
         "is_enabled": true,
@@ -1629,7 +1831,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan792": {
         "is_enabled": true,
@@ -1637,7 +1840,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan794": {
         "is_enabled": true,
@@ -1645,7 +1849,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan795": {
         "is_enabled": true,
@@ -1653,6 +1858,7 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     }
 }

--- a/tests/mock_driver/global/cisco/ios/get_interfaces.2
+++ b/tests/mock_driver/global/cisco/ios/get_interfaces.2
@@ -1733,7 +1733,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan760": {
         "is_enabled": true,

--- a/tests/mock_driver/global/cisco/ios/get_interfaces.2
+++ b/tests/mock_driver/global/cisco/ios/get_interfaces.2
@@ -5,7 +5,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/2": {
         "is_enabled": true,
@@ -13,7 +14,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/3": {
         "is_enabled": true,
@@ -21,7 +23,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:79",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/4": {
         "is_enabled": true,
@@ -29,7 +32,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7A",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/5": {
         "is_enabled": true,
@@ -37,7 +41,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7B",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/6": {
         "is_enabled": true,
@@ -45,7 +50,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7C",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/7": {
         "is_enabled": true,
@@ -53,7 +59,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7D",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/8": {
         "is_enabled": false,
@@ -61,7 +68,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/9": {
         "is_enabled": true,
@@ -69,7 +77,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7F",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/10": {
         "is_enabled": false,
@@ -77,7 +86,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/11": {
         "is_enabled": true,
@@ -85,7 +95,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:81",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/12": {
         "is_enabled": false,
@@ -93,7 +104,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/13": {
         "is_enabled": false,
@@ -101,7 +113,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/14": {
         "is_enabled": false,
@@ -109,7 +122,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/15": {
         "is_enabled": false,
@@ -117,7 +131,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/16": {
         "is_enabled": false,
@@ -125,7 +140,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/17": {
         "is_enabled": false,
@@ -133,7 +149,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/18": {
         "is_enabled": false,
@@ -141,7 +158,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/19": {
         "is_enabled": false,
@@ -149,7 +167,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/20": {
         "is_enabled": false,
@@ -157,7 +176,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/21": {
         "is_enabled": false,
@@ -165,7 +185,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/22": {
         "is_enabled": false,
@@ -173,7 +194,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/23": {
         "is_enabled": false,
@@ -181,7 +203,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/24": {
         "is_enabled": true,
@@ -189,7 +212,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8E",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/25": {
         "is_enabled": true,
@@ -197,7 +221,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8F",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/26": {
         "is_enabled": false,
@@ -205,7 +230,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/27": {
         "is_enabled": true,
@@ -213,7 +239,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:91",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/28": {
         "is_enabled": false,
@@ -221,7 +248,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/29": {
         "is_enabled": false,
@@ -229,7 +257,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/30": {
         "is_enabled": false,
@@ -237,7 +266,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/31": {
         "is_enabled": false,
@@ -245,7 +275,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/1/32": {
         "is_enabled": false,
@@ -253,7 +284,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/1": {
         "is_enabled": true,
@@ -261,7 +293,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/2": {
         "is_enabled": true,
@@ -269,7 +302,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/3": {
         "is_enabled": true,
@@ -277,7 +311,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:51",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/4": {
         "is_enabled": true,
@@ -285,7 +320,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:52",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/5": {
         "is_enabled": true,
@@ -293,7 +329,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:53",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/6": {
         "is_enabled": true,
@@ -301,7 +338,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:54",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/7": {
         "is_enabled": true,
@@ -309,7 +347,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:55",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/8": {
         "is_enabled": false,
@@ -317,7 +356,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/9": {
         "is_enabled": false,
@@ -325,7 +365,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/10": {
         "is_enabled": false,
@@ -333,7 +374,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/11": {
         "is_enabled": false,
@@ -341,7 +383,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/12": {
         "is_enabled": false,
@@ -349,7 +392,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/13": {
         "is_enabled": false,
@@ -357,7 +401,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/14": {
         "is_enabled": false,
@@ -365,7 +410,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/15": {
         "is_enabled": true,
@@ -373,7 +419,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5D",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/16": {
         "is_enabled": true,
@@ -381,7 +428,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5E",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/17": {
         "is_enabled": true,
@@ -389,7 +437,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5F",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/18": {
         "is_enabled": true,
@@ -397,7 +446,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:60",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/19": {
         "is_enabled": true,
@@ -405,7 +455,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:61",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/20": {
         "is_enabled": true,
@@ -413,7 +464,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:62",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/21": {
         "is_enabled": true,
@@ -421,7 +473,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:63",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/22": {
         "is_enabled": true,
@@ -429,7 +482,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:64",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/23": {
         "is_enabled": false,
@@ -437,7 +491,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/24": {
         "is_enabled": false,
@@ -445,7 +500,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/25": {
         "is_enabled": false,
@@ -453,7 +509,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/26": {
         "is_enabled": false,
@@ -461,7 +518,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/27": {
         "is_enabled": true,
@@ -469,7 +527,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/28": {
         "is_enabled": true,
@@ -477,7 +536,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/29": {
         "is_enabled": true,
@@ -485,7 +545,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/30": {
         "is_enabled": false,
@@ -493,7 +554,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/31": {
         "is_enabled": false,
@@ -501,7 +563,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/2/32": {
         "is_enabled": false,
@@ -509,7 +572,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/1": {
         "is_enabled": true,
@@ -517,7 +581,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/2": {
         "is_enabled": true,
@@ -525,7 +590,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/3": {
         "is_enabled": true,
@@ -533,7 +599,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3D",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/4": {
         "is_enabled": true,
@@ -541,7 +608,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3E",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/5": {
         "is_enabled": true,
@@ -549,7 +617,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3F",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/6": {
         "is_enabled": false,
@@ -557,7 +626,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/7": {
         "is_enabled": true,
@@ -565,7 +635,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:41",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet1/3/8": {
         "is_enabled": true,
@@ -573,7 +644,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:42",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet1/3/9": {
         "is_enabled": false,
@@ -581,7 +653,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet1/3/10": {
         "is_enabled": false,
@@ -589,7 +662,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "mgmt0": {
         "is_enabled": false,
@@ -597,7 +671,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/1": {
         "is_enabled": true,
@@ -605,7 +680,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/2": {
         "is_enabled": true,
@@ -613,7 +689,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/3": {
         "is_enabled": true,
@@ -621,7 +698,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:AE",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/4": {
         "is_enabled": true,
@@ -629,7 +707,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:AF",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/5": {
         "is_enabled": true,
@@ -637,7 +716,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B0",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/6": {
         "is_enabled": true,
@@ -645,7 +725,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B1",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/7": {
         "is_enabled": true,
@@ -653,7 +734,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B2",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/8": {
         "is_enabled": false,
@@ -661,7 +743,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/9": {
         "is_enabled": true,
@@ -669,7 +752,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B4",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/10": {
         "is_enabled": true,
@@ -677,7 +761,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B5",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/11": {
         "is_enabled": true,
@@ -685,7 +770,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B6",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/12": {
         "is_enabled": true,
@@ -693,7 +779,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B7",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/13": {
         "is_enabled": false,
@@ -701,7 +788,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/14": {
         "is_enabled": false,
@@ -709,7 +797,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/15": {
         "is_enabled": true,
@@ -717,7 +806,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:BA",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/16": {
         "is_enabled": false,
@@ -725,7 +815,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/17": {
         "is_enabled": false,
@@ -733,7 +824,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/18": {
         "is_enabled": false,
@@ -741,7 +833,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/19": {
         "is_enabled": false,
@@ -749,7 +842,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/20": {
         "is_enabled": true,
@@ -757,7 +851,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:BF",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/21": {
         "is_enabled": true,
@@ -765,7 +860,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C0",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/22": {
         "is_enabled": false,
@@ -773,7 +869,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/23": {
         "is_enabled": true,
@@ -781,7 +878,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C2",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/24": {
         "is_enabled": true,
@@ -789,7 +887,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C3",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/25": {
         "is_enabled": true,
@@ -797,7 +896,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C4",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/26": {
         "is_enabled": false,
@@ -805,7 +905,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/27": {
         "is_enabled": true,
@@ -813,7 +914,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:C6",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/28": {
         "is_enabled": false,
@@ -821,7 +923,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/29": {
         "is_enabled": false,
@@ -829,7 +932,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/30": {
         "is_enabled": false,
@@ -837,7 +941,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/31": {
         "is_enabled": false,
@@ -845,7 +950,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/1/32": {
         "is_enabled": false,
@@ -853,7 +959,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/1": {
         "is_enabled": true,
@@ -861,7 +968,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/2": {
         "is_enabled": true,
@@ -869,7 +977,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/3": {
         "is_enabled": true,
@@ -877,7 +986,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:64",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/4": {
         "is_enabled": true,
@@ -885,7 +995,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:65",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/5": {
         "is_enabled": true,
@@ -893,7 +1004,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:66",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/6": {
         "is_enabled": true,
@@ -901,7 +1013,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:67",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/7": {
         "is_enabled": true,
@@ -909,7 +1022,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:68",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/8": {
         "is_enabled": false,
@@ -917,7 +1031,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/9": {
         "is_enabled": false,
@@ -925,7 +1040,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/10": {
         "is_enabled": false,
@@ -933,7 +1049,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/11": {
         "is_enabled": false,
@@ -941,7 +1058,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/12": {
         "is_enabled": false,
@@ -949,7 +1067,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/13": {
         "is_enabled": false,
@@ -957,7 +1076,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/14": {
         "is_enabled": false,
@@ -965,7 +1085,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/15": {
         "is_enabled": true,
@@ -973,7 +1094,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:70",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/16": {
         "is_enabled": true,
@@ -981,7 +1103,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:71",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/17": {
         "is_enabled": true,
@@ -989,7 +1112,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:72",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/18": {
         "is_enabled": true,
@@ -997,7 +1121,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:73",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/19": {
         "is_enabled": true,
@@ -1005,7 +1130,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:74",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/20": {
         "is_enabled": true,
@@ -1013,7 +1139,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:75",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/21": {
         "is_enabled": true,
@@ -1021,7 +1148,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:76",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/22": {
         "is_enabled": true,
@@ -1029,7 +1157,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:77",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/23": {
         "is_enabled": true,
@@ -1037,7 +1166,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:78",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/24": {
         "is_enabled": false,
@@ -1045,7 +1175,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/25": {
         "is_enabled": false,
@@ -1053,7 +1184,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/26": {
         "is_enabled": false,
@@ -1061,7 +1193,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/27": {
         "is_enabled": true,
@@ -1069,7 +1202,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/28": {
         "is_enabled": true,
@@ -1077,7 +1211,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/29": {
         "is_enabled": true,
@@ -1085,7 +1220,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/30": {
         "is_enabled": true,
@@ -1093,7 +1229,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7F",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/31": {
         "is_enabled": true,
@@ -1101,7 +1238,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:80",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/2/32": {
         "is_enabled": true,
@@ -1109,7 +1247,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:81",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/1": {
         "is_enabled": true,
@@ -1117,7 +1256,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/2": {
         "is_enabled": true,
@@ -1125,7 +1265,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/3": {
         "is_enabled": false,
@@ -1133,7 +1274,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/4": {
         "is_enabled": true,
@@ -1141,7 +1283,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:E1",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/5": {
         "is_enabled": false,
@@ -1149,7 +1292,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/6": {
         "is_enabled": true,
@@ -1157,7 +1301,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:E3",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/7": {
         "is_enabled": false,
@@ -1165,7 +1310,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "TenGigabitEthernet2/3/8": {
         "is_enabled": false,
@@ -1173,7 +1319,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 10000
+        "speed": 10000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet2/3/9": {
         "is_enabled": false,
@@ -1181,7 +1328,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "FortyGigabitEthernet2/3/10": {
         "is_enabled": false,
@@ -1189,7 +1337,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Loopback0": {
         "is_enabled": true,
@@ -1197,7 +1346,8 @@
         "description": "",
         "mac_address": "",
         "last_flapped": -1.0,
-        "speed": 8000
+        "speed": 8000,
+        "mtu": 1500
     },
     "Port-channel1": {
         "is_enabled": true,
@@ -1205,7 +1355,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:79",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel2": {
         "is_enabled": true,
@@ -1213,7 +1364,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8F",
         "last_flapped": -1.0,
-        "speed": 20000
+        "speed": 20000,
+        "mtu": 1500
     },
     "Port-channel3": {
         "is_enabled": true,
@@ -1221,7 +1373,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7B",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel4": {
         "is_enabled": true,
@@ -1229,7 +1382,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:53",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel5": {
         "is_enabled": true,
@@ -1237,7 +1391,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:3D",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel6": {
         "is_enabled": true,
@@ -1245,7 +1400,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:8E",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel7": {
         "is_enabled": true,
@@ -1253,7 +1409,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B4",
         "last_flapped": -1.0,
-        "speed": 4000
+        "speed": 4000,
+        "mtu": 1500
     },
     "Port-channel10": {
         "is_enabled": true,
@@ -1261,7 +1418,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel20": {
         "is_enabled": true,
@@ -1269,7 +1427,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel21": {
         "is_enabled": true,
@@ -1277,7 +1436,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5D",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel22": {
         "is_enabled": true,
@@ -1285,7 +1445,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5E",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel23": {
         "is_enabled": true,
@@ -1293,7 +1454,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:5F",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel24": {
         "is_enabled": true,
@@ -1301,7 +1463,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:60",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel25": {
         "is_enabled": true,
@@ -1309,7 +1472,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:61",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel26": {
         "is_enabled": true,
@@ -1317,7 +1481,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:62",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel27": {
         "is_enabled": true,
@@ -1325,7 +1490,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:76",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel28": {
         "is_enabled": true,
@@ -1333,7 +1499,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:77",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Port-channel29": {
         "is_enabled": true,
@@ -1341,7 +1508,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:91",
         "last_flapped": -1.0,
-        "speed": 2000
+        "speed": 2000,
+        "mtu": 1500
     },
     "Port-channel30": {
         "is_enabled": true,
@@ -1349,7 +1517,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:65",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Port-channel31": {
         "is_enabled": true,
@@ -1357,7 +1526,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7D",
         "last_flapped": -1.0,
-        "speed": 20000
+        "speed": 20000,
+        "mtu": 1500
     },
     "Port-channel32": {
         "is_enabled": true,
@@ -1365,7 +1535,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:B2",
         "last_flapped": -1.0,
-        "speed": 20000
+        "speed": 20000,
+        "mtu": 1500
     },
     "Port-channel100": {
         "is_enabled": true,
@@ -1373,7 +1544,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:7C",
         "last_flapped": -1.0,
-        "speed": 40000
+        "speed": 40000,
+        "mtu": 1500
     },
     "Vlan1": {
         "is_enabled": false,
@@ -1381,7 +1553,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan4": {
         "is_enabled": true,
@@ -1389,7 +1562,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan7": {
         "is_enabled": true,
@@ -1397,7 +1571,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan502": {
         "is_enabled": true,
@@ -1405,7 +1580,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan510": {
         "is_enabled": true,
@@ -1413,7 +1589,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan538": {
         "is_enabled": true,
@@ -1421,7 +1598,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan601": {
         "is_enabled": true,
@@ -1429,7 +1607,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan602": {
         "is_enabled": true,
@@ -1437,7 +1616,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan606": {
         "is_enabled": true,
@@ -1445,7 +1625,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan607": {
         "is_enabled": true,
@@ -1453,7 +1634,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan608": {
         "is_enabled": true,
@@ -1461,7 +1643,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan609": {
         "is_enabled": true,
@@ -1469,7 +1652,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan610": {
         "is_enabled": true,
@@ -1477,7 +1661,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan702": {
         "is_enabled": true,
@@ -1485,7 +1670,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan707": {
         "is_enabled": true,
@@ -1493,7 +1679,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan710": {
         "is_enabled": true,
@@ -1501,7 +1688,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan711": {
         "is_enabled": true,
@@ -1509,7 +1697,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan736": {
         "is_enabled": true,
@@ -1517,7 +1706,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan745": {
         "is_enabled": true,
@@ -1525,7 +1715,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan746": {
         "is_enabled": true,
@@ -1533,7 +1724,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan754": {
         "is_enabled": true,
@@ -1549,7 +1741,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan762": {
         "is_enabled": false,
@@ -1557,7 +1750,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan764": {
         "is_enabled": false,
@@ -1565,7 +1759,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan765": {
         "is_enabled": false,
@@ -1573,7 +1768,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan766": {
         "is_enabled": true,
@@ -1581,7 +1777,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan772": {
         "is_enabled": true,
@@ -1589,7 +1786,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan778": {
         "is_enabled": true,
@@ -1597,7 +1795,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan783": {
         "is_enabled": true,
@@ -1605,7 +1804,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan786": {
         "is_enabled": true,
@@ -1613,7 +1813,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan788": {
         "is_enabled": true,
@@ -1621,7 +1822,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan790": {
         "is_enabled": true,
@@ -1629,7 +1831,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan792": {
         "is_enabled": true,
@@ -1637,7 +1840,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan794": {
         "is_enabled": true,
@@ -1645,7 +1849,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     },
     "Vlan795": {
         "is_enabled": true,
@@ -1653,6 +1858,7 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+        "mtu": 1500
     }
 }

--- a/tests/mock_driver/global/cisco/ios/test_get_interfaces.json
+++ b/tests/mock_driver/global/cisco/ios/test_get_interfaces.json
@@ -4,7 +4,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -14,7 +14,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -24,7 +24,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -34,7 +34,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -44,7 +44,7 @@
         "enabled": true,
         "mac_address": null,
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -54,7 +54,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:79",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -132,7 +132,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": "Link Aggregation Group (LAG)",
         "untagged_vlan": null
@@ -142,7 +142,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:7C",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "710",
             "760"
@@ -155,7 +155,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:8F",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "500",
             "792"
@@ -168,7 +168,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": "Link Aggregation Group (LAG)",
         "untagged_vlan": null
@@ -178,7 +178,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:5D",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -256,7 +256,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:5E",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -334,7 +334,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:5F",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -412,7 +412,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:60",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -490,7 +490,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:61",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -568,7 +568,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:62",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -646,7 +646,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:76",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -724,7 +724,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:77",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -802,7 +802,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:91",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "710",
             "754"
@@ -815,7 +815,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:7B",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "601",
             "602",
@@ -837,7 +837,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:65",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -915,7 +915,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:7D",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "5"
         ],
@@ -927,7 +927,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:B2",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "5"
         ],
@@ -939,7 +939,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:53",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "601",
             "602",
@@ -961,7 +961,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:3D",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1",
             "3",
@@ -1039,7 +1039,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:8E",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "511",
             "515",
@@ -1068,7 +1068,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:B4",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "507",
             "610",
@@ -1090,7 +1090,7 @@
         "lag": "Port-channel10",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1100,7 +1100,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1110,7 +1110,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:81",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "710"
         ],
@@ -1122,7 +1122,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1132,7 +1132,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1142,7 +1142,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1152,7 +1152,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1162,7 +1162,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1172,7 +1172,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1182,7 +1182,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1192,7 +1192,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1202,7 +1202,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1212,7 +1212,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1222,7 +1222,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1232,7 +1232,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1242,7 +1242,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1253,7 +1253,7 @@
         "lag": "Port-channel6",
         "mac_address": "00:00:00:00:00:8E",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1264,7 +1264,7 @@
         "lag": "Port-channel2",
         "mac_address": "00:00:00:00:00:8F",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1274,7 +1274,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1285,7 +1285,7 @@
         "lag": "Port-channel29",
         "mac_address": "00:00:00:00:00:91",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1295,7 +1295,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1305,7 +1305,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1316,7 +1316,7 @@
         "lag": "Port-channel1",
         "mac_address": "00:00:00:00:00:79",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1326,7 +1326,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1336,7 +1336,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1346,7 +1346,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1357,7 +1357,7 @@
         "lag": "Port-channel1",
         "mac_address": "00:00:00:00:00:7A",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1368,7 +1368,7 @@
         "lag": "Port-channel3",
         "mac_address": "00:00:00:00:00:7B",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1379,7 +1379,7 @@
         "lag": "Port-channel100",
         "mac_address": "00:00:00:00:00:7C",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1390,7 +1390,7 @@
         "lag": "Port-channel31",
         "mac_address": "00:00:00:00:00:7D",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": "5"
@@ -1400,7 +1400,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1410,7 +1410,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:7F",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "710"
         ],
@@ -1423,7 +1423,7 @@
         "lag": "Port-channel10",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1433,7 +1433,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1443,7 +1443,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1453,7 +1453,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1463,7 +1463,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1473,7 +1473,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1484,7 +1484,7 @@
         "lag": "Port-channel21",
         "mac_address": "00:00:00:00:00:5D",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1497,7 +1497,7 @@
         "lag": "Port-channel22",
         "mac_address": "00:00:00:00:00:5E",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1510,7 +1510,7 @@
         "lag": "Port-channel23",
         "mac_address": "00:00:00:00:00:5F",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1523,7 +1523,7 @@
         "lag": "Port-channel24",
         "mac_address": "00:00:00:00:00:60",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1536,7 +1536,7 @@
         "lag": "Port-channel25",
         "mac_address": "00:00:00:00:00:61",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1548,7 +1548,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1559,7 +1559,7 @@
         "lag": "Port-channel26",
         "mac_address": "00:00:00:00:00:62",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1572,7 +1572,7 @@
         "lag": "Port-channel27",
         "mac_address": "00:00:00:00:00:63",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1585,7 +1585,7 @@
         "lag": "Port-channel28",
         "mac_address": "00:00:00:00:00:64",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "1"
         ],
@@ -1597,7 +1597,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1607,7 +1607,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1617,7 +1617,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1627,7 +1627,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1637,7 +1637,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1647,7 +1647,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1657,7 +1657,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1668,7 +1668,7 @@
         "lag": "Port-channel1",
         "mac_address": "00:00:00:00:00:51",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1678,7 +1678,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1688,7 +1688,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1698,7 +1698,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1709,7 +1709,7 @@
         "lag": "Port-channel1",
         "mac_address": "00:00:00:00:00:52",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1720,7 +1720,7 @@
         "lag": "Port-channel4",
         "mac_address": "00:00:00:00:00:53",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1731,7 +1731,7 @@
         "lag": "Port-channel100",
         "mac_address": "00:00:00:00:00:54",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1742,7 +1742,7 @@
         "lag": "Port-channel31",
         "mac_address": "00:00:00:00:00:55",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": "5"
@@ -1752,7 +1752,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1762,7 +1762,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1773,7 +1773,7 @@
         "lag": "Port-channel10",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1784,7 +1784,7 @@
         "lag": "Port-channel10",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1795,7 +1795,7 @@
         "lag": "Port-channel5",
         "mac_address": "00:00:00:00:00:3D",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1805,7 +1805,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:3E",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "710"
         ],
@@ -1818,7 +1818,7 @@
         "lag": "Port-channel5",
         "mac_address": "00:00:00:00:00:3F",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1828,7 +1828,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1838,7 +1838,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:41",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "3",
             "2"
@@ -1851,7 +1851,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:42",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "4",
             "506",
@@ -1867,7 +1867,7 @@
         "lag": "Port-channel20",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1878,7 +1878,7 @@
         "lag": "Port-channel7",
         "mac_address": "00:00:00:00:00:B5",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1889,7 +1889,7 @@
         "lag": "Port-channel7",
         "mac_address": "00:00:00:00:00:B6",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1900,7 +1900,7 @@
         "lag": "Port-channel7",
         "mac_address": "00:00:00:00:00:B7",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1910,7 +1910,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1920,7 +1920,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1930,7 +1930,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:BA",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "507",
             "508"
@@ -1943,7 +1943,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1953,7 +1953,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1963,7 +1963,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1973,7 +1973,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1983,7 +1983,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -1993,7 +1993,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:BF",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "3",
             "2"
@@ -2006,7 +2006,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:C0",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "4",
             "506",
@@ -2021,7 +2021,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2031,7 +2031,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:C2",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "607"
         ],
@@ -2044,7 +2044,7 @@
         "lag": "Port-channel6",
         "mac_address": "00:00:00:00:00:C3",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2055,7 +2055,7 @@
         "lag": "Port-channel2",
         "mac_address": "00:00:00:00:00:C4",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2065,7 +2065,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2076,7 +2076,7 @@
         "lag": "Port-channel29",
         "mac_address": "00:00:00:00:00:C6",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2086,7 +2086,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2096,7 +2096,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2107,7 +2107,7 @@
         "lag": "Port-channel30",
         "mac_address": "00:00:00:00:00:AE",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2117,7 +2117,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2127,7 +2127,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2137,7 +2137,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2148,7 +2148,7 @@
         "lag": "Port-channel30",
         "mac_address": "00:00:00:00:00:AF",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2159,7 +2159,7 @@
         "lag": "Port-channel3",
         "mac_address": "00:00:00:00:00:B0",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2170,7 +2170,7 @@
         "lag": "Port-channel100",
         "mac_address": "00:00:00:00:00:B1",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2181,7 +2181,7 @@
         "lag": "Port-channel32",
         "mac_address": "00:00:00:00:00:B2",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": "5"
@@ -2191,7 +2191,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2202,7 +2202,7 @@
         "lag": "Port-channel7",
         "mac_address": "00:00:00:00:00:B4",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2213,7 +2213,7 @@
         "lag": "Port-channel20",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2223,7 +2223,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2233,7 +2233,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2243,7 +2243,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2253,7 +2253,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2263,7 +2263,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2274,7 +2274,7 @@
         "lag": "Port-channel21",
         "mac_address": "00:00:00:00:00:70",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2285,7 +2285,7 @@
         "lag": "Port-channel22",
         "mac_address": "00:00:00:00:00:71",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2296,7 +2296,7 @@
         "lag": "Port-channel23",
         "mac_address": "00:00:00:00:00:72",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2307,7 +2307,7 @@
         "lag": "Port-channel24",
         "mac_address": "00:00:00:00:00:73",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2318,7 +2318,7 @@
         "lag": "Port-channel25",
         "mac_address": "00:00:00:00:00:74",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2328,7 +2328,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2339,7 +2339,7 @@
         "lag": "Port-channel26",
         "mac_address": "00:00:00:00:00:75",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2350,7 +2350,7 @@
         "lag": "Port-channel27",
         "mac_address": "00:00:00:00:00:76",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2361,7 +2361,7 @@
         "lag": "Port-channel28",
         "mac_address": "00:00:00:00:00:77",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2371,7 +2371,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:78",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "607"
         ],
@@ -2383,7 +2383,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2393,7 +2393,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2403,7 +2403,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2413,7 +2413,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2423,7 +2423,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2433,7 +2433,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2444,7 +2444,7 @@
         "lag": "Port-channel30",
         "mac_address": "00:00:00:00:00:64",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2454,7 +2454,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:7F",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "448",
             "500",
@@ -2486,7 +2486,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:80",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "507",
             "710",
@@ -2501,7 +2501,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:81",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "507",
             "508",
@@ -2517,7 +2517,7 @@
         "lag": "Port-channel30",
         "mac_address": "00:00:00:00:00:65",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2528,7 +2528,7 @@
         "lag": "Port-channel4",
         "mac_address": "00:00:00:00:00:66",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2539,7 +2539,7 @@
         "lag": "Port-channel100",
         "mac_address": "00:00:00:00:00:67",
         "mode": "Tagged",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2550,7 +2550,7 @@
         "lag": "Port-channel32",
         "mac_address": "00:00:00:00:00:68",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": "5"
@@ -2560,7 +2560,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2570,7 +2570,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2581,7 +2581,7 @@
         "lag": "Port-channel20",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2592,7 +2592,7 @@
         "lag": "Port-channel20",
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2602,7 +2602,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2612,7 +2612,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:E1",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "710"
         ],
@@ -2624,7 +2624,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2634,7 +2634,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:E3",
         "mode": "Access",
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [
             "710"
         ],
@@ -2646,7 +2646,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2656,7 +2656,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2666,7 +2666,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2676,7 +2676,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2686,7 +2686,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2696,7 +2696,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2706,7 +2706,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2716,7 +2716,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2726,7 +2726,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2736,7 +2736,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2746,7 +2746,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2756,7 +2756,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2766,7 +2766,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2776,7 +2776,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2786,7 +2786,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2796,7 +2796,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2806,7 +2806,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2816,7 +2816,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2826,7 +2826,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2836,7 +2836,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2846,7 +2846,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2856,7 +2856,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2866,7 +2866,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2876,7 +2876,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2886,7 +2886,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2896,7 +2896,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2906,7 +2906,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2916,7 +2916,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2926,7 +2926,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2936,7 +2936,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2946,7 +2946,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2956,7 +2956,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2966,7 +2966,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2976,7 +2976,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2986,7 +2986,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -2996,7 +2996,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -3006,7 +3006,7 @@
         "enabled": true,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null
@@ -3016,7 +3016,7 @@
         "enabled": false,
         "mac_address": "00:00:00:00:00:40",
         "mode": null,
-        "mtu": null,
+        "mtu": 1500,
         "tagged_vlans": [],
         "type": null,
         "untagged_vlan": null

--- a/tests/mock_driver/global/cisco/nxos/get_interfaces.1
+++ b/tests/mock_driver/global/cisco/nxos/get_interfaces.1
@@ -5,7 +5,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:60",
-        "speed": 0
+        "speed": 0,
+		"mtu": 1500
     },
     "Ethernet1/1": {
         "description": "is simply",
@@ -13,7 +14,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:68",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/2": {
         "description": "is simply",
@@ -21,7 +23,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:69",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/3": {
         "description": "is simply",
@@ -29,7 +32,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6A",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/4": {
         "description": "is simply",
@@ -37,7 +41,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6B",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/5": {
         "description": "is simply",
@@ -45,7 +50,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6C",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/6": {
         "description": "is simply",
@@ -53,7 +59,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6D",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/7": {
         "description": "is simply",
@@ -61,7 +68,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6E",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/8": {
         "description": "is simply",
@@ -69,7 +77,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6F",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/9": {
         "description": "is simply",
@@ -77,7 +86,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:70",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/10": {
         "description": "is simply",
@@ -85,7 +95,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:71",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/11": {
         "description": "is simply",
@@ -93,7 +104,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:72",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/12": {
         "description": "is simply",
@@ -101,7 +113,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:73",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/13": {
         "description": "",
@@ -109,7 +122,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/14": {
         "description": "",
@@ -117,7 +131,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/15": {
         "description": "",
@@ -125,7 +140,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:76",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/16": {
         "description": "",
@@ -133,7 +149,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/17": {
         "description": "",
@@ -141,7 +158,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/18": {
         "description": "",
@@ -149,7 +167,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/19": {
         "description": "",
@@ -157,7 +176,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/20": {
         "description": "",
@@ -165,7 +185,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/21": {
         "description": "dummy text",
@@ -173,7 +194,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:7C",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/22": {
         "description": "dummy text",
@@ -181,7 +203,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:7D",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/23": {
         "description": "dummy text",
@@ -189,7 +212,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:7E",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/24": {
         "description": "dummy text",
@@ -197,7 +221,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:7F",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/25": {
         "description": "dummy text",
@@ -205,7 +230,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:80",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/26": {
         "description": "dummy text",
@@ -213,7 +239,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:81",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/27": {
         "description": "dummy text",
@@ -221,7 +248,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:82",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/28": {
         "description": "dummy text",
@@ -229,7 +257,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:83",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/29": {
         "description": "dummy text",
@@ -237,7 +266,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:84",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/30": {
         "description": "dummy text",
@@ -245,7 +275,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:85",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/31": {
         "description": "dummy text",
@@ -253,7 +284,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:86",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/32": {
         "description": "dummy text",
@@ -261,7 +293,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:87",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/33": {
         "description": "dummy text",
@@ -269,7 +302,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:88",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/34": {
         "description": "dummy text",
@@ -277,7 +311,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:89",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/35": {
         "description": "dummy text",
@@ -285,7 +320,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8A",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/36": {
         "description": "of the printing",
@@ -293,7 +329,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8B",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/37": {
         "description": "of the printing",
@@ -301,7 +338,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8C",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/38": {
         "description": "of the printing",
@@ -309,7 +347,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8D",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/39": {
         "description": "",
@@ -317,7 +356,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/40": {
         "description": "",
@@ -325,7 +365,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/41": {
         "description": "",
@@ -333,7 +374,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/42": {
         "description": "",
@@ -341,7 +383,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/43": {
         "description": "Trunk",
@@ -349,7 +392,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/44": {
         "description": "Trunk",
@@ -357,7 +401,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/45": {
         "description": "",
@@ -365,7 +410,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/46": {
         "description": "",
@@ -373,7 +419,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 25000
+        "speed": 25000,
+		"mtu": 1500
     },
     "Ethernet1/47": {
         "description": "Trunk",
@@ -381,7 +428,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:96",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/48": {
         "description": "Trunk",
@@ -389,7 +437,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:97",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "Ethernet1/49": {
         "description": "",
@@ -397,7 +446,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 40000
+        "speed": 40000,
+		"mtu": 1500
     },
     "Ethernet1/50": {
         "description": "",
@@ -405,7 +455,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 100000
+        "speed": 100000,
+		"mtu": 1500
     },
     "Ethernet1/51": {
         "description": "",
@@ -413,7 +464,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 40000
+        "speed": 40000,
+		"mtu": 1500
     },
     "Ethernet1/52": {
         "description": "",
@@ -421,7 +473,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 100000
+        "speed": 100000,
+		"mtu": 1500
     },
     "Ethernet1/53": {
         "description": "",
@@ -429,7 +482,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 40000
+        "speed": 40000,
+		"mtu": 1500
     },
     "Ethernet1/54": {
         "description": "",
@@ -437,7 +491,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 40000
+        "speed": 40000,
+		"mtu": 1500
     },
     "port-channel12": {
         "description": "lorem ipsum",
@@ -445,7 +500,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:7C",
-        "speed": 40000
+        "speed": 40000,
+		"mtu": 1500
     },
     "port-channel22": {
         "description": "lorem ipsum",
@@ -453,7 +509,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8C",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel23": {
         "description": "lorem ipsum",
@@ -461,7 +518,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8D",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel24": {
         "description": "lorem ipsum",
@@ -469,7 +527,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6E",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel25": {
         "description": "lorem ipsum",
@@ -477,7 +536,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6F",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel26": {
         "description": "",
@@ -485,7 +545,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:80",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel27": {
         "description": "",
@@ -493,7 +554,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:81",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel28": {
         "description": "",
@@ -501,7 +563,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:82",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel29": {
         "description": "",
@@ -509,7 +572,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:85",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel30": {
         "description": "",
@@ -517,7 +581,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:89",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel31": {
         "description": "",
@@ -525,7 +590,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:68",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel32": {
         "description": "",
@@ -533,7 +599,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:69",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel33": {
         "description": "",
@@ -541,7 +608,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6A",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel34": {
         "description": "",
@@ -549,7 +617,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:86",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel35": {
         "description": "",
@@ -557,7 +626,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:88",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel36": {
         "description": "",
@@ -565,7 +635,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8A",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel37": {
         "description": "",
@@ -573,7 +644,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:8B",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel38": {
         "description": "",
@@ -581,7 +653,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6B",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel39": {
         "description": "",
@@ -589,7 +662,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6C",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel40": {
         "description": "",
@@ -597,7 +671,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:6D",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel41": {
         "description": "",
@@ -605,7 +680,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:83",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel42": {
         "description": "",
@@ -613,7 +689,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:84",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel43": {
         "description": "",
@@ -621,7 +698,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:73",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel44": {
         "description": "",
@@ -629,7 +707,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:70",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel45": {
         "description": "",
@@ -637,7 +716,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:71",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel46": {
         "description": "",
@@ -645,7 +725,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:72",
-        "speed": 10000
+        "speed": 10000,
+		"mtu": 1500
     },
     "port-channel100": {
         "description": "",
@@ -653,7 +734,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:96",
-        "speed": 20000
+        "speed": 20000,
+		"mtu": 1500
     },
     "port-channel101": {
         "description": "",
@@ -661,7 +743,8 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "00:00:00:00:00:67",
-        "speed": 20000
+        "speed": 20000,
+		"mtu": 1500
     },
     "Vlan1": {
         "description": "",
@@ -669,7 +752,8 @@
         "is_up": false,
         "last_flapped": -1.0,
         "mac_address": "",
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 0
     },
     "Vlan177": {
         "description": "",
@@ -677,6 +761,7 @@
         "is_up": true,
         "last_flapped": -1.0,
         "mac_address": "",
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 0
     }
 }

--- a/tests/mock_driver/global/junos/get_interfaces.1
+++ b/tests/mock_driver/global/junos/get_interfaces.1
@@ -1,50 +1,60 @@
 {
     "lo0": {
         "is_up": true, "is_enabled": false, "description": "lorem ipsum",
-        "last_flapped": -1.0, "speed": 0, "mac_address": "CC:46:D6:6E:0F:70"
+        "last_flapped": -1.0, "speed": 0, "mac_address": "CC:46:D6:6E:0F:70",
+		"mtu": 1500
     },
     "ge-0/0/0": {
         "is_up": true, "is_enabled": true, "description": "is simply",
         "last_flapped": 1478175306.5162635, "speed": 1000,
-        "mac_address": "CC:46:D6:6E:0F:78"
+        "mac_address": "CC:46:D6:6E:0F:78",
+		"mtu": 1500
     },
     "ge-0/0/1": {
         "is_up": true, "is_enabled": true, "description": "dummy text",
         "last_flapped": 1492172106.5163276, "speed": 1000,
-        "mac_address": "CC:46:D6:6E:0F:79"
+        "mac_address": "CC:46:D6:6E:0F:79",
+		"mtu": 1500
     },
     "ae10": {
         "is_up": true, "is_enabled": true, "description": "of the printing",
         "last_flapped": -1.0, "speed": 2000,
-        "mac_address": "CC:46:D6:6E:0F:82"
+        "mac_address": "CC:46:D6:6E:0F:82",
+		"mtu": 1500
     },
     "ae11": {
         "is_up": true, "is_enabled": true,
         "description": "and typesetting industry",
         "last_flapped": -1.0, "speed": 2000,
-        "mac_address": "CC:46:D6:6E:0F:83"
+        "mac_address": "CC:46:D6:6E:0F:83",
+		"mtu": 1500
     },
     "ae12": {
         "is_up": true, "is_enabled": true, "description": "lorem ipsum",
         "last_flapped": -1.0, "speed": 2000,
-        "mac_address": "CC:46:D6:6E:0F:7D"
+        "mac_address": "CC:46:D6:6E:0F:7D",
+		"mtu": 1500
     },
     "vlan.1": {
         "is_up": false, "is_enabled": false, "description": "",
-        "last_flapped": -1.0, "speed": 0, "mac_address": ""
+        "last_flapped": -1.0, "speed": 0, "mac_address": "",
+		"mtu": 1500
     },
     "vlan.200": {
         "is_up": false, "is_enabled": false, "description": "",
-        "last_flapped": -1.0, "speed": 0, "mac_address": ""
+        "last_flapped": -1.0, "speed": 0, "mac_address": "",
+		"mtu": 1500
     },
     "ge-1/0/0": {
         "is_up": true, "is_enabled": true, "description": "",
         "last_flapped": 1467375306.5194001, "speed": 1000,
-        "mac_address": "38:20:56:95:4B:C2"
+        "mac_address": "38:20:56:95:4B:C2",
+		"mtu": 1500
     },
     "ge-1/0/1": {
         "is_up": false, "is_enabled": false, "description": "has been the",
         "last_flapped": -1.0, "speed": 1000,
-        "mac_address": "38:20:56:95:4B:C3"
+        "mac_address": "38:20:56:95:4B:C3",
+		"mtu": 1500
     }
 }

--- a/tests/mock_driver/specific/cisco/ios/get_interfaces.1
+++ b/tests/mock_driver/specific/cisco/ios/get_interfaces.1
@@ -5,7 +5,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:40",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "Vlan710": {
         "is_enabled": true,
@@ -13,7 +14,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:41",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "FastEthernet0": {
         "is_enabled": false,
@@ -21,7 +23,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:39",
         "last_flapped": -1.0,
-        "speed": 100
+        "speed": 100,
+		"mtu": 1500
     },
     "GigabitEthernet0/1": {
         "is_enabled": true,
@@ -29,7 +32,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:01",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/2": {
         "is_enabled": true,
@@ -37,7 +41,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:02",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/3": {
         "is_enabled": true,
@@ -45,7 +50,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:03",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/4": {
         "is_enabled": true,
@@ -53,7 +59,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:04",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/5": {
         "is_enabled": true,
@@ -61,7 +68,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:05",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/6": {
         "is_enabled": true,
@@ -69,7 +77,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:06",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/7": {
         "is_enabled": true,
@@ -77,7 +86,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:07",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/8": {
         "is_enabled": true,
@@ -85,7 +95,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:08",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/9": {
         "is_enabled": true,
@@ -93,7 +104,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:09",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/10": {
         "is_enabled": true,
@@ -101,7 +113,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:0A",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/11": {
         "is_enabled": true,
@@ -109,7 +122,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:0B",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/12": {
         "is_enabled": true,
@@ -117,7 +131,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:0C",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/13": {
         "is_enabled": true,
@@ -125,7 +140,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:0D",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/14": {
         "is_enabled": true,
@@ -133,7 +149,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:0E",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/15": {
         "is_enabled": true,
@@ -141,7 +158,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:0F",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/16": {
         "is_enabled": true,
@@ -149,7 +167,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:10",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/17": {
         "is_enabled": false,
@@ -157,7 +176,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:11",
         "last_flapped": -1.0,
-        "speed": 10
+        "speed": 10,
+		"mtu": 1500
     },
     "GigabitEthernet0/18": {
         "is_enabled": false,
@@ -165,7 +185,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:12",
         "last_flapped": -1.0,
-        "speed": 10
+        "speed": 10,
+		"mtu": 1500
     },
     "GigabitEthernet0/19": {
         "is_enabled": false,
@@ -173,7 +194,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:13",
         "last_flapped": -1.0,
-        "speed": 10
+        "speed": 10,
+		"mtu": 1500
     },
     "GigabitEthernet0/20": {
         "is_enabled": false,
@@ -181,7 +203,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:14",
         "last_flapped": -1.0,
-        "speed": 10
+        "speed": 10,
+		"mtu": 1500
     },
     "GigabitEthernet0/21": {
         "is_enabled": true,
@@ -189,7 +212,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:15",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/22": {
         "is_enabled": true,
@@ -197,7 +221,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:16",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/23": {
         "is_enabled": true,
@@ -205,7 +230,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:17",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "GigabitEthernet0/24": {
         "is_enabled": true,
@@ -213,7 +239,8 @@
         "description": "",
         "mac_address": "00:00:00:00:00:18",
         "last_flapped": -1.0,
-        "speed": 1000
+        "speed": 1000,
+		"mtu": 1500
     },
     "Port-channel1": {
         "is_enabled": true,
@@ -221,6 +248,7 @@
         "description": "",
         "mac_address": "00:00:00:00:00:16",
         "last_flapped": -1.0,
-        "speed": 4000
+        "speed": 4000,
+		"mtu": 1500
     }
 }


### PR DESCRIPTION
If napalm cannot determine it, it defaults to 0, and netbox accepts values greater than 0 or Null